### PR TITLE
Add reuseport functionality to websocket protocol

### DIFF
--- a/p2p/transport/websocket/addrs_test.go
+++ b/p2p/transport/websocket/addrs_test.go
@@ -69,7 +69,8 @@ func TestConvertWebsocketMultiaddrToNetAddr(t *testing.T) {
 }
 
 func TestListeningOnDNSAddr(t *testing.T) {
-	ln, err := newListener(ma.StringCast("/dns/localhost/tcp/0/ws"), nil)
+	wt := &WebsocketTransport{}
+	ln, err := wt.newListener(ma.StringCast("/dns/localhost/tcp/0/ws"), nil)
 	require.NoError(t, err)
 	addr := ln.Multiaddr()
 	first, rest := ma.SplitFirst(addr)

--- a/p2p/transport/websocket/reuseport.go
+++ b/p2p/transport/websocket/reuseport.go
@@ -1,0 +1,9 @@
+package websocket
+
+import (
+	"github.com/libp2p/go-reuseport"
+)
+
+func reuseportIsAvailable() bool {
+	return reuseport.Available()
+}

--- a/p2p/transport/websocket/websocket_test.go
+++ b/p2p/transport/websocket/websocket_test.go
@@ -572,7 +572,7 @@ func TestReusePortOnDial(t *testing.T) {
 	require.NoError(t, err)
 	defer l.Close()
 
-	// Take a note of the port on which we listen. This should be the address from which we dial too.
+	// Take a note of the multiaddress on which we listen. This should be the address from which we dial too.
 	expectedAddr := l.Multiaddr()
 
 	done := make(chan struct{})
@@ -583,6 +583,7 @@ func TestReusePortOnDial(t *testing.T) {
 		require.NoError(t, err)
 		defer conn.Close()
 
+		// The meat of this test - verify that the connection was received from the same port as the listen port recorded above.
 		remote := conn.RemoteMultiaddr()
 		require.Equal(t, expectedAddr, remote)
 	}()
@@ -590,10 +591,6 @@ func TestReusePortOnDial(t *testing.T) {
 	conn, err := tpt.Dial(context.Background(), cliListen.Multiaddr(), clientID)
 	require.NoError(t, err)
 	defer conn.Close()
-
-	stream, err := conn.OpenStream(context.Background())
-	require.NoError(t, err)
-	defer stream.Close()
 
 	<-done
 }


### PR DESCRIPTION
This PR adds the reuseport functionality for websocket.

The `TestReusePortOnDial` tests this implementation by starting to listen on a random port, then dialing another _endpoint_ and verifying that the dial used the same port it was listening on.

It seems to work, though when I run the test multiple times (>= 100) it will sporadically fail.

```go
	conn, err := tpt.Dial(context.Background(), cliListen.Multiaddr(), clientID)
	require.NoError(t, err)
	defer conn.Close()

	stream, err := conn.OpenStream(context.Background())
	require.NoError(t, err) // <----------------------------------------- this line fails
	defer stream.Close()
```

The error reported is mostly `EOF` but sometimes `close sent`.


I'm not sure if there's a bug in the test case or in the code, but the same test case will fail on mater too. AND, the vanilla tests on master regularly log errors too:

```
2024/02/08 14:35:57 http: TLS handshake error from 127.0.0.1:55478: read tcp4 127.0.0.1:37817->127.0.0.1:55478: use of closed network connection
2024/02/08 14:35:57 http: TLS handshake error from 127.0.0.1:54424: read tcp4 127.0.0.1:45011->127.0.0.1:54424: use of closed network connection
2024/02/08 14:35:58 http: TLS handshake error from 127.0.0.1:54968: read tcp4 127.0.0.1:42575->127.0.0.1:54968: use of closed network connection
```
